### PR TITLE
Update memory offsets for 5.05

### DIFF
--- a/EnmityPlugin/FFXIVMemory.cs
+++ b/EnmityPlugin/FFXIVMemory.cs
@@ -392,6 +392,7 @@ namespace Tamagawa.EnmityPlugin
                     combatant.Level = p[offset + 66];
 
                     // Status aka Buff,Debuff
+                    combatant.Statuses = new List<Status>();
                     const int StatusEffectOffset = 6292 + 196 + 16;
                     const int statusSize = 12;
 
@@ -400,9 +401,6 @@ namespace Tamagawa.EnmityPlugin
 
                     var statusesSource = new byte[statusCountLimit * statusSize];
                     Buffer.BlockCopy(source, StatusEffectOffset, statusesSource, 0, statusCountLimit * statusSize);
-
-                    combatant.Statuses = new List<Status>();
-
                     for (var i = 0; i < statusCountLimit; i++)
                     {
                         var statusBytes = new byte[statusSize];

--- a/EnmityPlugin/FFXIVMemory.cs
+++ b/EnmityPlugin/FFXIVMemory.cs
@@ -379,7 +379,7 @@ namespace Tamagawa.EnmityPlugin
 
                 combatant.TargetID = *(uint*)&p[5832 + 8];
 
-                offset = 5960 + 8;
+                offset = 6292 + 8;
                 if (combatant.type == ObjectType.PC || combatant.type == ObjectType.Monster)
                 {
                     combatant.CurrentHP = *(int*)&p[offset + 8];
@@ -393,7 +393,7 @@ namespace Tamagawa.EnmityPlugin
 
                     // Status aka Buff,Debuff
                     combatant.Statuses = new List<Status>();
-                    const int StatusEffectOffset = 6152 + 16;
+                    const int StatusEffectOffset = 6292 + 208 + 16; //TODO: unsure, seems to line up in memory
                     const int statusSize = 12;
 
                     int statusCountLimit = 60;

--- a/EnmityPlugin/FFXIVMemory.cs
+++ b/EnmityPlugin/FFXIVMemory.cs
@@ -392,8 +392,7 @@ namespace Tamagawa.EnmityPlugin
                     combatant.Level = p[offset + 66];
 
                     // Status aka Buff,Debuff
-                    combatant.Statuses = new List<Status>();
-                    const int StatusEffectOffset = 6292 + 208 + 16; //TODO: unsure, seems to line up in memory
+                    const int StatusEffectOffset = 6292 + 196 + 16;
                     const int statusSize = 12;
 
                     int statusCountLimit = 60;
@@ -401,6 +400,9 @@ namespace Tamagawa.EnmityPlugin
 
                     var statusesSource = new byte[statusCountLimit * statusSize];
                     Buffer.BlockCopy(source, StatusEffectOffset, statusesSource, 0, statusCountLimit * statusSize);
+
+                    combatant.Statuses = new List<Status>();
+
                     for (var i = 0; i < statusCountLimit; i++)
                     {
                         var statusBytes = new byte[statusSize];
@@ -423,10 +425,10 @@ namespace Tamagawa.EnmityPlugin
                     // Cast
                     combatant.Casting = new Cast
                     {
-                        ID = *(short*)&p[6900 + 16],
-                        TargetID = *(uint*)&p[6912 + 16],
-                        Progress = *(Single*)&p[6948 + 16],
-                        Time = *(Single*)&p[6952 + 16],
+                        ID = *(short*)&p[7236 + 16],
+                        TargetID = *(uint*)&p[7248 + 16],
+                        Progress = *(Single*)&p[7280 + 16],
+                        Time = *(Single*)&p[7284 + 16],
                     };
                 }
                 else


### PR DESCRIPTION
Hi, saw your comments on the Discord server. I updated the offset for HP values and status effects but I'm unsure exactly how the status effects are used and can't test them.
